### PR TITLE
bug in breaking encoded mimewords into individual lines

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -1010,11 +1010,22 @@ MailComposer.prototype._encodeMimeWord = function(str, encoding, maxlen){
     encoding = (encoding || "Q").toUpperCase(); 
     if(this._hasUTFChars(str)){
         str = mimelib.encodeMimeWord(str, encoding);
-        if(maxlen && str.length>maxlen){
-            return str.replace(new RegExp(".{"+maxlen+"}","g"),"$&?= =?UTF-8?"+encoding+"?");
-        }else{
-            return str;
+
+        var str_parts = [];
+        // strip terminating ?= to avoid some mess
+        str = str.substr(0, str.length - 2);
+        while (maxlen && str.length>maxlen) {
+            var pin = maxlen;
+            if (str[pin - 1] == "=") pin -= 1;
+            else if (str[pin - 2] == "=") pin -= 2;
+
+            str_parts.push(str.substr(0, pin) + "?=");
+            str = str.substr(pin);
         }
+        if (str.length > 0) str_parts.push(str + "?=");
+
+        for (var i = 1; i < str_parts.length; ++i) str_parts[i] = "=?UTF-8?"+encoding+"?" + str_parts[i];
+        return str_parts.join(' ');
     }else{
         return str;
     }


### PR DESCRIPTION
Test code:

```
var e = new (require('./mailcomposer').MailComposer);
console.log(e._encodeMimeWord('INFO: Uživatel XXXXXX XěXXX přidal...', 'Q', 50).replace(/ /g, '\r\n'));
```

This produces following output:

```
=?UTF-8?Q?INFO:_U=C5=BEivatel_XXXXXX_X=C4=9BXXX_p=?=
=?UTF-8?Q?C5=99idal...?=
```

That lone = (part of =C5 byte) on first line, when put in subject header, causes Thunderbird to consider the whole encoding as invalid and display the subject as plaintext instead of decoding it. Another (webmail) client can parse most of it, but result is "INFO: Uživatel XXXXXX X=C5XXX přidal..." which is not right either.

This patch is probably somewhat inefficient with all the string copying and spliting, but at least all mail clients I tried understand it's output.
