### PR TITLE
Variable "len" flagged as global

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -136,7 +136,7 @@ MailComposer.prototype.addHeader = function(key, value){
 MailComposer.prototype.setMessageOption = function(options){
     var fields = ["from", "to", "cc", "bcc", "replyTo", "subject", "body", "html", "envelope"],
         rewrite = {"sender":"from", "reply_to":"replyTo", "text":"body"}
-	len;
+	    len;
     
     options = options || {};
     
@@ -803,7 +803,7 @@ MailComposer.prototype._composeBody = function(){
     var flatTree = this._message.flatTree,
         slice, isObject = false, isEnd = false,
         curObject,
-	len;
+        len;
     
     this._message.processingStart = this._message.processingStart || 0;
     this._message.processingPos = this._message.processingPos || 0;


### PR DESCRIPTION
I've got some global warnings when running `mocha` in my application using `nodemailer`. In this commit, I've made sure that the `len` variable now is setup locally.
