### PR TITLE
Allow specifying of transfer encoding other than base64 for an attachment

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -1047,10 +1047,11 @@ MailComposer.prototype._serveFile = function(filePath, encoding, callback){
  * @param {Function} callback Callback function to run after completion
  */
 MailComposer.prototype._serveStream = function(stream, encoding, callback){
-    var remainder = new Buffer(0);
-    var base64 = encoding === 'base64';
+    var remainder = new Buffer(0),
+        qpCR = false,
+        base64 = encoding === "base64", qp = encoding === "quoted-printable";
     if(!base64)
-        encoding = 'utf-8';
+        encoding = "utf-8";
 
     stream.on("error", (function(error){
         if(!this._cacheOutput){
@@ -1064,6 +1065,8 @@ MailComposer.prototype._serveStream = function(stream, encoding, callback){
     }).bind(this));
     
     stream.on("data", (function(chunk){
+        if(!chunk.length)
+            return;
         if(base64){
             var data = "",
                 len = remainder.length + chunk.length,
@@ -1084,25 +1087,66 @@ MailComposer.prototype._serveStream = function(stream, encoding, callback){
                     this._outputBuffer += data.trim()+"\r\n";
                 }
             }
-        }else if(chunk.length){
+        }else if(qp){
+            var data = "",
+                len = remainder.length + chunk.length,
+                remainderLength = 0, // we use 57 bytes as it composes
+                                            // a 76 bytes long base64 string
+                buffer = new Buffer(len),
+                lastCRLF = -1;
+            
+            if(qpCR && chunk[0] === 10){
+                chunk = chunk.substr(1);
+            }
+            qpCR = chunk[chunk.length-1] === 13;
+
+            remainder.copy(buffer); // copy remainder into the beginning of the new buffer
+            chunk.copy(buffer, remainder.length); // copy data chunk after the remainder
+            remainder = buffer;
+
+            data = mimelib.encodeQuotedPrintable(buffer.toString("utf-8"));
+            lastCRLF = data.lastIndexOf("\r\n");
+
+            if(lastCRLF !== -1){
+                // decode back the remainder
+                remainder = new Buffer(
+                    mimelib.decodeQuotedPrintable(data.substring(lastCRLF + 2).toString("utf-8")),
+                    "utf-8");
+
+                if(!this._cacheOutput){
+                    this.emit("data", new Buffer(data.substring(0, lastCRLF + 2), "utf-8"));
+                }else{
+                    this._outputBuffer += data.substring(0, lastCRLF + 2);
+                }
+            }
+        }else{
             if(!this._cacheOutput){
                 this.emit("data", chunk);
             }else{
-                this._outputBuffer += chunk.toString(encoding);
+                this._outputBuffer += chunk.toString("utf-8");
             }
         }
     }).bind(this));
     
     stream.on("end", (function(chunk){
-        var data;
+        var data = "";
         
         // stream the remainder (if any)
-        if(base64 && remainder.length){
-            data = remainder.toString("base64").replace(/.{76}/g,"$&\r\n");
+        if(remainder.length){
+            if(base64){
+                data = remainder.toString("base64").replace(/.{76}/g,"$&\r\n").trim()+"\r\n";
+            }else if(qp){
+                data = mimelib.encodeQuotedPrintable(remainder.toString('utf-8'));
+            }
+        } else if(!base64){
+            data = "\r\n";
+        }
+
+        if(data.length) {
             if(!this._cacheOutput){
-                this.emit("data", new Buffer(data.trim()+"\r\n", "utf-8"));
+                this.emit("data", new Buffer(data, "utf-8"));
             }else{
-                this._outputBuffer += data.trim()+"\r\n";
+                this._outputBuffer += data;
             }
         }
         process.nextTick(callback);


### PR DESCRIPTION
Sometimes we need to specify content transfer encoding other than base64 for an attachment, for example, when forwarding email as a message/rfc822 attachment which requires 7bit, 8bit or binary encoding. (http://tools.ietf.org/html/rfc2046#section-5.2.1)
