### PR TITLE
Add iCalender Support

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -542,7 +542,7 @@ MailComposer.prototype._composeHeader = function(){
         this._message.useMixed = false;
     }
     
-    ifif( (this._message.body && this._message.html) || (this._message.body && this._message.ical) || (this._message.html && this._message.ical) {
+    if( (this._message.body && this._message.html) || (this._message.body && this._message.ical) || (this._message.html && this._message.ical)) {
         this._message.useAlternative = true;
         this._message.alternativeBoundary = this._generateBoundary();
     }else{


### PR DESCRIPTION
iCalender (ics) files could be send as attachments. This is not compatible to Microsoft Outlook behaviour. Therefore I added iCalender support as used by Outlook.
