### PR TITLE
Include charset and method on alternatives

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -960,6 +960,12 @@ MailComposer.prototype._createAlternativeComponent = function(alternative){
         contentType.push("format=" + node.textFormat);
     }
 
+    if(alternative.charset){
+        contentType.push("charset=" + alternative.charset);
+    }
+    if(alternative.method){
+        contentType.push("method=" + alternative.method);
+    }
     node.headers.push(["Content-Type", contentType.join("; ")]);
     node.headers.push(["Content-Transfer-Encoding", node.contentEncoding]);
 


### PR DESCRIPTION
When the alternative node contains charset and/or method, include those when building the resulting Content-Type line. 

This is related to sending multipart alternative messages with text/calendar and mail messages generated from mailparser. See https://github.com/andris9/mailparser/issues/82
