### PR TITLE
fix utf-8 headers quotations

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -564,9 +564,9 @@ MailComposer.prototype._convertAddress = function(address){
         if(this._hasUTFChars(address.name)){
             address.name = this._encodeMimeWord(address.name, "Q", 52);
         }else{
-            address.name = address.name;
+            address.name = JSON.stringify(address.name);
         }
-        return JSON.stringify(address.name) + ' <'+address.address+'>';
+        return address.name + ' <'+address.address+'>';
     }
 };
 


### PR DESCRIPTION
After I talk with Mandrill support team, I find out that some mail header generating by mailcomposer library are not compatible with the RFC-2822.

The problem is when I send utf-8 characters on mail names like:

```
mailcomposer.setMessageOption({
  from: '"דבלופמנט ישראל" <bug@test.com>',
  // ...
});
```

mailcomposer doing excellent work and convert the UTF-8 chars correctly but adding an incorrect quotations as follows:

```
From: "=?UTF-8?Q?=D7=93=D7=91=D7=9C=D7=95=D7=A4=D7=9E?=
 =?UTF-8?Q?=D7=A0=D7=98_=D7=99=D7=A9=D7=A8=D7=90?= =?UTF-8?Q?=D7=9C?=" 
<bug@test.com>
```

Instead it's should passed without the opening and closing quotations, as:

```
From: =?UTF-8?Q?=D7=93=D7=91=D7=9C=D7=95=D7=A4=D7=9E?=
 =?UTF-8?Q?=D7=A0=D7=98_=D7=99=D7=A9=D7=A8=D7=90?= =?UTF-8?Q?=D7=9C?= 
<bug@test.com>
```

This patch fix that.
Thank you!
