### PR TITLE
fix _encodeMimeWord special symbols on address name

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -562,11 +562,7 @@ MailComposer.prototype._convertAddress = function(address){
         return address.address;
     }else if(address.name){
         if(this._hasUTFChars(address.name)){
-            address.name = this._encodeMimeWord(address.name, "Q", 52)
-			.replace(/[^\w\?!*=+-]/g, function(chr){
-                var code = chr.charCodeAt(0);
-                return "=" + (code<0x10?"0":"") + code.toString(16).toUpperCase();
-            });
+            address.name = this._encodePartialMimeWord(address.name, "Q", 52);
         }else{
             address.name = JSON.stringify(address.name);
         }
@@ -1459,6 +1455,32 @@ MailComposer.prototype._generateBoundary = function(){
  */
 MailComposer.prototype._encodeMimeWord = function(str, encoding, maxlen){
     return mimelib.encodeMimeWords(str, encoding, maxlen, this.options.charset);
+};
+
+/**
+ * <p>Converts a partial string to mime word format. If the length is longer than
+ * <code>maxlen</code>, split it</p>
+ *
+ * <p>If the string doesn't have any unicode characters return the original
+ * string instead</p>
+ *
+ * @param {String} str String to be encoded
+ * @param {String} encoding Either Q for Quoted-Printable or B for Base64
+ * @param {Number} [maxlen] Optional length of the resulting string, whitespace will be inserted if needed
+ *
+ * @return {String} Mime-word encoded string (if needed)
+ */
+MailComposer.prototype._encodePartialMimeWord = function(str, encoding, maxlen){
+    return str.replace(/[^\s]*[^\s\w\?!*=+-]+[^\s]*(\s+[^\s]*[^\s\w\?!*=+-]+[^\s]*)*/g, (function(str, o){
+        if(!str.length)
+            return '';
+	
+        return mimelib.encodeMimeWord(str, encoding, this.options.charset, maxlen)
+        .replace(/[^\w\s\?!*=+-]/g, function(chr){
+            var code = chr.charCodeAt(0);
+            return "=" + (code<0x10?"0":"") + code.toString(16).toUpperCase();
+        });
+    }).bind(this));	
 };
 
 /**

--- a/test/mailcomposer.js
+++ b/test/mailcomposer.js
@@ -312,7 +312,13 @@ exports["Text encodings"] = {
             sender: '"Jaanuar Veebruar, Märts" <märts@märts.eu>'
         });
 
-        test.equal(mc._message.from, "\"Jaanuar Veebruar, =?UTF-8?Q?M=C3=A4rts?=\" <=?UTF-8?Q?m=C3=A4rts?=@xn--mrts-loa.eu>");
+        test.equal(mc._message.from, "Jaanuar =?UTF-8?Q?Veebruar=2C_M=C3=A4rts?= <=?UTF-8?Q?m=C3=A4rts?=@xn--mrts-loa.eu>");
+		
+        mc.setMessageOption({
+            sender: '"Ноде Майлер" <Mayler@nodejs.org>'
+        });
+
+        test.equal(mc._message.from, "=?UTF-8?Q?=D0=9D=D0=BE=D0=B4=D0=B5_=D0=9C=D0=B0?= =?UTF-8?Q?=D0=B9=D0=BB=D0=B5=D1=80?= <Mayler@nodejs.org>");
 
         mc.setMessageOption({
             sender: 'aavik <aavik@node.ee>'


### PR DESCRIPTION
This fix will support special symbols on address names.

Code tested via: http://dogmamix.com/MimeHeadersDecoder/
Comply with [RFC-2047](https://tools.ietf.org/html/rfc2047#section-5) (3)
Original code based on [mimelib](https://github.com/andris9/mimelib) library.

Test code:

```
var str = mimelib.encodeMimeWords('שלום ע-ולם!,+fjAJD<>:;.\'/()[]"', 'Q'),

encodedStr = str.replace(/[^\w\?!*=+-]/g, function(chr){
    var code = chr.charCodeAt(0);
    return "=" + (code<0x10?"0":"") + code.toString(16).toUpperCase();
});

console.log(encodedStr);
```

Will output the valid encoded word:

```
=?UTF-8?Q?=D7=A9=D7=9C=D7=95=D7=9D_=D7=A2-=D7=95=D7=9C=D7=9D!=2C+fjAJD=3C=3E=3A=3B=2E=27=2F=28=29=5B=5D=22?=
```
