### PR TITLE
Simplify Punycoding logic

### DIFF
--- a/lib/topunycode.js
+++ b/lib/topunycode.js
@@ -4,7 +4,6 @@ var punycode = require("punycode");
 
 module.exports = function(address) {
     return address.replace(/((?:https?:\/\/)?.*\@)?([^\/]*)/, function(o, start, domain) {
-        var domainParts = domain.split(/\./).map(punycode.toASCII.bind(punycode));
-        return (start || "") + domainParts.join(".");
+        return (start || "") + punycode.toASCII(domain);
     });
 };


### PR DESCRIPTION
There’s no need to split the host into labels yourself – Punycode.js takes care of that for you.

With this patch, the code does not only become simpler, but you also gain [RFC 3490 separator](https://github.com/bestiejs/punycode.js/blob/7fad5f381ac5e7928864b7848540a25f180a01e0/punycode.js#L36) support for free.
