### PR TITLE
Setting min node version to 0.8 removing punycode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 0.8
+  - 0.10
   - 0.11
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "mimelib": "~0.2.15",
     "mime": "~1.2.11",
     "he": "~0.3.6",
-    "punycode": "~1.2.4",
     "follow-redirects": "0.0.3",
     "dkim-signer": "~0.1.1"
   },
@@ -36,7 +35,7 @@
     "mailparser": "~0.4.0"
   },
   "engine": {
-    "node": ">=0.4"
+    "node": ">=0.8"
   },
   "keywords": [
     "e-mail",


### PR DESCRIPTION
I was getting a warning that punycode is included in node core and saw that travis testing wasn't handling < 0.6.2 when punycode was officially added.
